### PR TITLE
Adding unit tests for the server recipe

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.getchef.com"
+
+metadata

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,0 +1,15 @@
+DEPENDENCIES
+  sql_server
+    path: .
+    metadata: true
+
+GRAPH
+  chef-sugar (3.1.0)
+  chef_handler (1.1.6)
+  openssl (4.0.0)
+    chef-sugar (>= 0.0.0)
+  sql_server (2.2.3)
+    openssl (>= 0.0.0)
+    windows (>= 1.2.6)
+  windows (1.36.6)
+    chef_handler (>= 0.0.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -1,0 +1,71 @@
+#
+# Cookbook Name:: sql_server
+# Spec:: server
+#
+# Copyright (c) 2015 Irving Popovetsky, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'sql_server::server' do
+
+  context 'When all attributes are default, on Windows 2008R2, it should converge successfully' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+  context 'When all attributes are default, on Windows 2012, it should converge successfully' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2012')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+  context 'When specifying an Array of admin users for "sysadmins"' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2012', file_cache_path: 'C:\chef\cache') do |node|
+        node.set['sql_server']['sysadmins'] = ['Administrator', 'Fred', 'Barney']
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'creates the correct ConfigurationFile.ini template' do
+      expect(chef_run).to create_template('C:\chef\cache\ConfigurationFile.ini')
+      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator Fred Barney"$/)
+    end
+
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+  context 'When specifying a String for "sysadmins"' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2012', file_cache_path: 'C:\chef\cache') do |node|
+        node.set['sql_server']['sysadmins'] = 'Administrator'
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'creates the correct ConfigurationFile.ini template' do
+      expect(chef_run).to create_template('C:\chef\cache\ConfigurationFile.ini')
+      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^"SQLSYSADMINACCOUNTS=Administrator"$/)
+    end
+
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+end


### PR DESCRIPTION
Hey @jerrelblankenship -  I really appreciate the effort you've put in to your sql_server cookbook PR and I want to see it merged successfully :smile: 

I fully understand that it's hard work to submit a PR,  but it's even harder to be the maintainer of a project and to evaluate code quality of a PR.  We're constantly working to improve community cookbooks and that means not impacting the many existing users of this cookbook.

My philosophy is to leave the cookbook in a better state than I found it.  The most straightforward way to do that is to add tests.   To help you along, I've written a few Unit tests in [ChefSpec](http://sethvargo.github.io/chefspec/) where I'm hoping to express your desired state.   Please note that these don't pass right now, but will pass once you make the changes we discussed.

If you're unfamiliar with running Chefspec, the simplest way is to change to the cookbook directory and run `rspec`.     If `rspec` isn't in your path, assuming you have a recent ChefDK, try running `chef exec rspec`
